### PR TITLE
Fixed hiding of setup exception due to a NPE in TransactionHandler

### DIFF
--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionHandler.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionHandler.java
@@ -167,8 +167,12 @@ public abstract class TransactionHandler
     */
    private boolean testRequiresRollbackDueToFailure()
    {
-      final Status actualStatus = testResultInstance.get().getStatus();
-      return TestResult.Status.FAILED.equals(actualStatus);
+      if(testResultInstance.get() != null)
+      {
+          final Status actualStatus = testResultInstance.get().getStatus();
+          return TestResult.Status.FAILED.equals(actualStatus);
+      }
+      return true;
    }
 
    /**


### PR DESCRIPTION
When the setup of a testcase fails due to some exception when setting up CDI context, the TransactionHandler throws a NullPointerException while trying to determine the transaction result (rollback or commit). This masks the original exception making it hard to figure out what goes wrong when building a context for test cases.

You can see the particular testcase here: https://github.com/dashorst/arquillian-transaction-npe-test 

The commit in this PR fixes the NPE and doesn't hide the original exception 