### PR TITLE
Make sure @After runs within transaction bounds

### DIFF
--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionHandler.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionHandler.java
@@ -99,11 +99,11 @@ public abstract class TransactionHandler
    {
       try
       {
-         endTransaction(afterTestContext.getEvent());
+    	  afterTestContext.proceed();
       }
       finally
       {
-         afterTestContext.proceed();
+    	  endTransaction(afterTestContext.getEvent());
       }
    }
 


### PR DESCRIPTION
Since 1.1.7, @After is called as part of a TestLifecycleEvent rather then directly from Arquillian. To make sure @After remains within the transaction bounds, TransactionHandler must first proceed and then end the transaction.
