### PR TITLE
Avoid NPE when properties file doesn't contain property

### DIFF
--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/configuration/TransactionConfigurationConverter.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/configuration/TransactionConfigurationConverter.java
@@ -104,7 +104,7 @@ public class TransactionConfigurationConverter
 
       String value = properties.getProperty(propertyName);
 
-      if ("".equals(value.trim()))
+      if (value == null || "".equals(value.trim()))
       {
          return null;
       }


### PR DESCRIPTION
Arquillian TomEE remote connector in versions 1.7.0 and 1.7.1 has properties file without transactionDefaultMode property so the configuration is created with DEFAULT TransactionMode but NPE occurs.