### PR TITLE
Fix for hidden exception during test setup.

### DIFF
--- a/impl-jta/src/main/java/org/jboss/arquillian/transaction/jta/provider/JtaTransactionProvider.java
+++ b/impl-jta/src/main/java/org/jboss/arquillian/transaction/jta/provider/JtaTransactionProvider.java
@@ -100,7 +100,11 @@ public class JtaTransactionProvider implements TransactionProvider
    {
       try
       {
-         userTransactionInstance.get().rollback();
+         UserTransaction userTransaction = userTransactionInstance.get();
+
+         if (userTransaction != null) {
+            userTransaction.rollback();
+         }
       }
       catch (Exception e)
       {


### PR DESCRIPTION
Hello,

I think this bugfix is very similar to #9 .

If some exception occurs during the test-setup (for example, my datasets contain invalid data), the original exception is still hidden by an NPE. The NPE occurs during the rollback of the transaction. (I'm not totally sure, that there is any transaction.)

See one example here: https://github.com/vilmosnagy/arquillian-transaction-bug

There are 3 test-cases:
 * `test_should_pass_without_dataset`: in this test-case no dataset used, test passes.
 * `test_should_pass_with_dataset`: test uses a correct dataset, passes
 * `test_should_fail_with_incorrect_dataset`: test uses an incorrect dataset (one row contains an invalid column name), and NPE occurs, instead of ...

Here is the NPE's stack trace (the last lines only):

    Caused by: java.lang.NullPointerException
        at org.jboss.arquillian.transaction.jta.provider.JtaTransactionProvider.rollbackTransaction(JtaTransactionProvider.java:103)
        ... 117 more

And here's the original exception, thrown by H2:

    Caused by: org.dbunit.dataset.NoSuchColumnException: TEST_ENTITY.NOT_EXISTING_COLUMN -  (Non-uppercase input column: not_existing_column) in ColumnNameToIndexes cache map. Note that the map's column names are NOT case sensitive.
        at org.dbunit.dataset.AbstractTableMetaData.getColumnIndex(AbstractTableMetaData.java:117)
        at org.dbunit.operation.AbstractOperation.getOperationMetaData(AbstractOperation.java:89)
        at org.dbunit.operation.AbstractBatchOperation.execute(AbstractBatchOperation.java:143)
        at org.jboss.arquillian.persistence.dbunit.DBUnitDataHandler.seedDatabase(DBUnitDataHandler.java:167)
        at org.jboss.arquillian.persistence.dbunit.DBUnitDataHandler.prepare(DBUnitDataHandler.java:87)
        ... 191 more

I'd be happy to see the second exception, if something fails during the initialization of a test-case.