### PR TITLE
Resolves TransactionProviderNotFoundException when no TransactionHandler is found

### DIFF
--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.transaction.impl.lifecycle.TransactionHandler;
 import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
 
 public class ClientSideTransactionHandler extends TransactionHandler {
+    
     @Inject
     private Instance<Deployment> deploymentInstance;
 
@@ -47,7 +48,7 @@ public class ClientSideTransactionHandler extends TransactionHandler {
 
         final TransactionProvider transactionProvider =
                 serviceLoaderInstance.get().onlyOne(TransactionProvider.class);
-        if(transactionProvider == null) {
+        if (transactionProvider == null) {
             return false;
         }
 

--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
@@ -42,7 +42,6 @@ public class ClientSideTransactionHandler extends TransactionHandler {
     @Inject
     private Instance<ServiceLoader> serviceLoaderInstance;
 
-
     @Override
     public boolean isTransactionSupported(TestEvent testEvent) {
 

--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java
@@ -21,10 +21,12 @@ import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.client.deployment.Deployment;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.core.spi.context.ApplicationContext;
 import org.jboss.arquillian.test.spi.event.suite.TestEvent;
 import org.jboss.arquillian.transaction.impl.lifecycle.ModeChecker;
 import org.jboss.arquillian.transaction.impl.lifecycle.TransactionHandler;
+import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
 
 public class ClientSideTransactionHandler extends TransactionHandler {
     @Inject
@@ -36,8 +38,19 @@ public class ClientSideTransactionHandler extends TransactionHandler {
     @Inject
     private Instance<ApplicationContext> applicationContextInstance;
 
+    @Inject
+    private Instance<ServiceLoader> serviceLoaderInstance;
+
+
     @Override
     public boolean isTransactionSupported(TestEvent testEvent) {
+
+        final TransactionProvider transactionProvider =
+                serviceLoaderInstance.get().onlyOne(TransactionProvider.class);
+        if(transactionProvider == null) {
+            return false;
+        }
+
         return new ModeChecker(deploymentInstance.get(), containerInstance.get()).isClientMode(testEvent);
     }
 }

--- a/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionProviderProducer.java
+++ b/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionProviderProducer.java
@@ -44,8 +44,7 @@ public class TransactionProviderProducer {
             final TransactionProvider transactionProvider =
                 serviceLoaderInstance.get().onlyOne(TransactionProvider.class);
             if (transactionProvider == null) {
-                throw new TransactionProviderNotFoundException(
-                    "Transaction provider for given test case has not been found.");
+                return;
             }
             transactionProviderProducer.set(transactionProvider);
         } catch (IllegalStateException e) {

--- a/impl-base/src/test/java/org/jboss/arquillian/transaction/impl/lifecycle/ClientSideTransactionHandlerTestCase.java
+++ b/impl-base/src/test/java/org/jboss/arquillian/transaction/impl/lifecycle/ClientSideTransactionHandlerTestCase.java
@@ -206,6 +206,28 @@ public class ClientSideTransactionHandlerTestCase extends AbstractTestTestBase {
     }
 
     @Test
+    public void shouldNotStartTransactionWhenNoTransactionProividerIsFound() throws Exception {
+
+        when(mockServiceLoader.onlyOne(TransactionProvider.class)).thenReturn(null);
+
+        getManager().getContext(ClassContext.class).activate(TestClass.class);
+
+        Object instance = new TestClass();
+        Method testMethod = instance.getClass().getMethod("defaultTest");
+
+        getManager().fire(new org.jboss.arquillian.test.spi.event.suite.Before(instance, testMethod));
+
+        // checks if the transaction context hasn't been created
+        verifyZeroInteractions(mockTransactionContext);
+
+        // verifies that the transaction hasn't been started
+        verifyZeroInteractions(mockTransactionProvider);
+
+        getManager().getContext(ClassContext.class).deactivate();
+    }
+
+
+    @Test
     public void shouldRollbackTransaction() throws Exception {
 
         getManager().getContext(ClassContext.class).activate(TestClass.class);


### PR DESCRIPTION
 #### Short description of what this resolves:

Resolves `TransactionProviderNotFoundException` for tests which don't have a `TransactionProvider`

#### Changes proposed in this pull request:

 It changes `TransactionProviderProducer` to not throw an exception when no `TransactionProvider` is found [here](https://github.com/rmpestano/arquillian-extension-transaction/blob/master/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionProviderProducer.java#L46).

It also disables `ClientSideTransactionHandler` when no `TransactionProvider` is found [here](https://github.com/rmpestano/arquillian-extension-transaction/blob/master/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/client/ClientSideTransactionHandler.java#L51)

I tried to use current `TransactionHandler` to verify if transaction is supported in [TransactionProviderProducer here](https://github.com/rmpestano/arquillian-extension-transaction/blob/master/impl-base/src/main/java/org/jboss/arquillian/transaction/impl/lifecycle/TransactionProviderProducer.java#L56)
but TransactionHandler is always null when `registerTransactionProvider` event is fired.

Fixes #14
