### PR TITLE
upgrade javax.transaction to Jakarta Transaction API 2.0.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jboss.arquillian.extension</groupId>
     <artifactId>arquillian-transaction-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.jboss.arquillian.extension</groupId>
   <artifactId>arquillian-transaction-bom</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Transaction Extension: BOM</name>
   <url>http://arquillian.org</url>

--- a/impl-base/pom.xml
+++ b/impl-base/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jboss.arquillian.extension</groupId>
     <artifactId>arquillian-transaction-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/impl-jta/pom.xml
+++ b/impl-jta/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.arquillian.extension</groupId>
     <artifactId>arquillian-transaction-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
   <description>JTA implementation for transaction extension</description>
 
   <properties>
-    <version.jta>1.1</version.jta>
+    <version.jta>2.0.1</version.jta>
   </properties>
 
   <dependencies>
@@ -36,8 +36,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.transaction</groupId>
-      <artifactId>jta</artifactId>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
       <version>${version.jta}</version>
       <scope>provided</scope>
     </dependency>

--- a/impl-jta/src/main/java/org/jboss/arquillian/transaction/jta/provider/JtaTransactionProvider.java
+++ b/impl-jta/src/main/java/org/jboss/arquillian/transaction/jta/provider/JtaTransactionProvider.java
@@ -26,9 +26,9 @@ import org.jboss.arquillian.transaction.spi.test.TransactionalTest;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
-import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
 
 public class JtaTransactionProvider implements TransactionProvider {
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.jboss.arquillian.extension</groupId>
   <artifactId>arquillian-transaction-parent</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Arquillian Transaction Extension: Parent</name>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jboss.arquillian.extension</groupId>
     <artifactId>arquillian-transaction-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
#### Changes proposed in this pull request:
- switched snapshot version to 2.0.0-SNAPSHOT
- migrated to Jakarta Transaction API 2.0.1
- change import javax.* to jakarta.*

